### PR TITLE
Fixed the positioning of accordion button arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* :bug: **Bugfix** Fixed position of arrow in accordion component
+
 # 0.2.1
 > Feb 26, 2021
 

--- a/projects/ng-components/src/lib/fhi-accordion/fhi-accordion.scss
+++ b/projects/ng-components/src/lib/fhi-accordion/fhi-accordion.scss
@@ -27,7 +27,8 @@
         }
         
         &__toggle-icon{
-            display: block;
+            display: flex;
+            justify-content: center;
             font-size: 48px;
             transition: transform 300ms ease;
             &--open{


### PR DESCRIPTION
Arrow icon in accordion button was placed to high, fixed with flexbox centre